### PR TITLE
Enable ZMK mouse support with customizable defaults

### DIFF
--- a/config/lily58.conf
+++ b/config/lily58.conf
@@ -4,3 +4,5 @@
 
 # Uncomment the following line to enable the Lily58 OLED Display
 # CONFIG_ZMK_DISPLAY=y
+
+CONFIG_ZMK_POINTING=y

--- a/config/lily58.keymap
+++ b/config/lily58.keymap
@@ -8,6 +8,9 @@
 #include <dt-bindings/zmk/bt.h>
 #include <dt-bindings/zmk/ext_power.h>
 #include <dt-bindings/zmk/keys.h>
+#define ZMK_POINTING_DEFAULT_MOVE_VAL 1500 // default: 600
+#define ZMK_POINTING_DEFAULT_SCRL_VAL 20 // default: 10
+
 #include <dt-bindings/zmk/pointing.h>
 
 / {


### PR DESCRIPTION
## Summary
- enable ZMK pointing feature for lily58 build
- set default mouse move and scroll speeds in keymap

## Testing
- `west build -d build -b nice_nano_v2 zmk/app -- -DSHIELD=lily58_left` *(fails: Could not find a package configuration file provided by "Zephyr-sdk" (requested version 0.16))*

------
https://chatgpt.com/codex/tasks/task_b_689da9cfbd9c8324bc958b486b93ea82